### PR TITLE
Register methods to autocompletion

### DIFF
--- a/src/ExalgoCompletionProvider.ts
+++ b/src/ExalgoCompletionProvider.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 import * as primitives from './definitions/primitives';
+import * as methods from './definitions/methods';
+import * as parameters from './definitions/parameters';
 
 /**
  * Provide the Exlago language completion by extending the CompletionItemProvider
@@ -13,26 +15,88 @@ export class ExalgoCompletionProvider implements vscode.CompletionItemProvider {
 	 * @param token
 	 */
 	provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.CompletionItem[]> {
+		/**
+		 * @TODO check the document extension, and reprovide the completion items on active text editor change
+		 */
+
 		const completions: vscode.CompletionItem[] = [];
 
-		primitives.getExalgoPrimitivesString().forEach(element => {
-			completions.push(new vscode.CompletionItem(element));
-		});
+		//Register all regular expressions
+		completions.concat(this.getAllRegExItems());
 
-		const varCompletion = new vscode.CompletionItem('Var');
-		varCompletion.insertText = new vscode.SnippetString('Var ${1} : ${2|' + primitives.getExalgoPrimitivesString() +'|} $0');
-		completions.push(varCompletion);
+		//Register all primitives
+		completions.concat(this.getAllPrimitivesItems());
 
-		const functionCompletion = new vscode.CompletionItem('Fonction');
-		functionCompletion.insertText = new vscode.SnippetString('Fonction ${1}() : ${2|int,String,boolean|}\n\nDébut\n$0\nFin');
-		completions.push(functionCompletion);
-
-
-		const forCompletion = new vscode.CompletionItem('Pour');
-		forCompletion.insertText = new vscode.SnippetString('Pour ${1} de ${2} à ${3} Faire\n');
-		completions.push(forCompletion);
-
+		//Register all methods
+		completions.concat(this.getAllMethodsItems());
 
 		return Promise.resolve(completions);
+	}
+
+	/**
+	 * Create all the completion items related to the exalgo's promitives
+	 * @return all exalgo primitives items
+	 */
+	getAllPrimitivesItems(): vscode.CompletionItem[] {
+		const items: vscode.CompletionItem[] = [];
+		primitives.getExalgoPrimitivesString().forEach(element => {
+			items.push(new vscode.CompletionItem(element, vscode.CompletionItemKind.Variable));
+		});
+		return items;
+	}
+
+	/**
+	 * Create all the completion items related to the exalgo's methods
+	 * @return all exalgo methods items
+	 */
+	getAllMethodsItems(): vscode.CompletionItem[] {
+		const items: vscode.CompletionItem[] = [];
+
+		methods.getAllMethods().forEach(element => {
+			const params: string[] = [];
+
+			let snippetsParams = '';
+			let pcount = 1;
+
+			//Foreach methods : parameters are created as a snippet string
+			element.parameters?.forEach((param: parameters.IParameter) => {
+				params.push(param.type.toString());
+				snippetsParams += '${' + pcount + '}';
+				if (pcount != element.parameters?.length)//If not last param, we add to the string coma and space:
+					snippetsParams += ', ';
+				pcount++;
+			});
+
+			const methodItem = new vscode.CompletionItem(element.name + `(${params.toString()})`, vscode.CompletionItemKind.Method);
+			methodItem.insertText = new vscode.SnippetString(`${element.name}(${snippetsParams})\n$0`);
+
+			items.push(methodItem);
+		});
+		return items;
+	}
+
+	/**
+	 * Create all the completion items related to the exalgo's regular expressions
+	 * (For/Var/Fonction/...)
+	 * @return all exalgo regex items
+	 */
+	getAllRegExItems(): vscode.CompletionItem[] {
+		const items: vscode.CompletionItem[] = [];
+
+		const varCompletion = new vscode.CompletionItem('Var', vscode.CompletionItemKind.Keyword);
+		varCompletion.insertText = new vscode.SnippetString('Var ${1} : ${2|' + primitives.getExalgoPrimitivesString() + '|} $0');
+		items.push(varCompletion);
+
+		const functionCompletion = new vscode.CompletionItem('Fonction', vscode.CompletionItemKind.Keyword);
+		functionCompletion.insertText = new vscode.SnippetString('Fonction ${1}() : ${2|' + primitives.getExalgoPrimitivesString() + '|}\n\nDébut\n$0\nFin');
+		items.push(functionCompletion);
+
+		const forCompletion = new vscode.CompletionItem('Pour', vscode.CompletionItemKind.Keyword);
+		forCompletion.insertText = new vscode.SnippetString('Pour ${1} de ${2} à ${3} Faire\n');
+		items.push(forCompletion);
+
+		items.push(new vscode.CompletionItem('=', vscode.CompletionItemKind.Operator));
+		items.push(new vscode.CompletionItem('<-', vscode.CompletionItemKind.Operator));
+		return items;
 	}
 }

--- a/src/definitions/classes.ts
+++ b/src/definitions/classes.ts
@@ -1,0 +1,4 @@
+/**
+ * @TODO classes -> Chaine, Graphe, Sommet ...
+ *
+ */

--- a/src/definitions/methods.ts
+++ b/src/definitions/methods.ts
@@ -21,12 +21,20 @@ export interface IExalgoMethods {
 	return: primitives.ExalgoPrimitives | null | string,
 }
 
+/**
+ *
+ */
+export function getAllMethods(): IExalgoMethods[] {
+	return exalgoMethods
+		.concat(exalgoMethodsGraphs)
+		.concat(exalgoMethodsDiGraphs);
+}
 
 export const exalgoMethods: IExalgoMethods[] = [
 	{
 		name: 'écrire',
 		parameters: [
-			{ type: '', enterType: parameters.EnterParameter.E }
+			{ type: 'chaîne', enterType: parameters.EnterParameter.E }
 		],
 		description: 'Affiche dans la console',
 		return: null,
@@ -35,7 +43,7 @@ export const exalgoMethods: IExalgoMethods[] = [
 		name: 'entierAléatoire',
 		parameters: [
 			{ type: primitives.ExalgoPrimitives.Entier, enterType: parameters.EnterParameter.E },
-			{ type: '', enterType: parameters.EnterParameter.E }
+			{ type: primitives.ExalgoPrimitives.Entier, enterType: parameters.EnterParameter.E }
 		],
 		description: 'Renvoie un entier aléatoire compris entre les premier paramètre (inclu) et le second paramètre',
 		return: primitives.ExalgoPrimitives.Entier,


### PR DESCRIPTION
Les méthodes que l'ont a faites l'autre jour sont désormais inscrites dans l'autocomplétions 
Ce qui fais que si l'on tape entierA -> "entierAléatoire(Entier, Entier)", les paramètres sont compris dans les snippets (Quand on fais tab on passe aux paramètres suivant avec le curseur